### PR TITLE
Simplify add holding flow by auto-fetching asset details

### DIFF
--- a/src/app/api/assets/fetch-details/route.ts
+++ b/src/app/api/assets/fetch-details/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchAssetDetails, AssetDetails } from '@/lib/services/price-fetcher';
+import { ApiResponse, AssetType } from '@/types/api';
+
+interface FetchAssetDetailsRequest {
+  symbol: string;
+  type: AssetType;
+}
+
+// POST /api/assets/fetch-details - Fetch asset details (name and price) from external APIs
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as FetchAssetDetailsRequest;
+
+    // Validate required fields
+    if (!body.symbol || !body.symbol.trim()) {
+      return NextResponse.json<ApiResponse<never>>(
+        { error: 'Asset symbol is required' },
+        { status: 400 }
+      );
+    }
+
+    if (!body.type || (body.type !== 'stock' && body.type !== 'crypto')) {
+      return NextResponse.json<ApiResponse<never>>(
+        { error: 'Valid asset type (stock or crypto) is required' },
+        { status: 400 }
+      );
+    }
+
+    const symbol = body.symbol.trim().toUpperCase();
+
+    // Fetch asset details from external API
+    const details = await fetchAssetDetails(symbol, body.type);
+
+    return NextResponse.json<ApiResponse<AssetDetails>>(
+      { data: details },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('Error fetching asset details:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Failed to fetch asset details';
+    return NextResponse.json<ApiResponse<never>>(
+      { error: errorMessage },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Updated the "Add Holding" form to automatically fetch asset name and current price from external APIs, removing the need for users to manually enter this information. Users now only need to select the asset type, enter the symbol, and specify the quantity.

Changes:
- Added fetchAssetDetails() function to fetch asset name and price
- Created POST /api/assets/fetch-details endpoint for fetching asset data
- Removed Asset Name and Current Price input fields from EditPortfolioForm
- Added loading states and error handling for API calls
- Simplified user experience while maintaining all functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)