### PR TITLE
Fix inconsistent UI terminology from 'Holdings' to 'Assets'

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -407,34 +407,34 @@ a:hover {
   font-size: 2rem;
 }
 
-/* Holdings Table */
-.holdings-table {
+/* Assets Table */
+.assets-table {
   overflow-x: auto;
   margin-top: 1rem;
 }
 
-.holdings-table table {
+.assets-table table {
   width: 100%;
   border-collapse: collapse;
 }
 
-.holdings-table thead {
+.assets-table thead {
   background: #f8f9fa;
 }
 
-.holdings-table th,
-.holdings-table td {
+.assets-table th,
+.assets-table td {
   padding: 1rem;
   text-align: left;
   border-bottom: 1px solid #eee;
 }
 
-.holdings-table th {
+.assets-table th {
   font-weight: 600;
   color: #2c3e50;
 }
 
-.holdings-table tbody tr:hover {
+.assets-table tbody tr:hover {
   background: #f8f9fa;
 }
 
@@ -442,33 +442,33 @@ a:hover {
   text-align: right;
 }
 
-/* Holdings Edit List */
-.holdings-edit-list {
+/* Assets Edit List */
+.assets-edit-list {
   margin-top: 1.5rem;
 }
 
-.holdings-edit-list table {
+.assets-edit-list table {
   width: 100%;
   border-collapse: collapse;
 }
 
-.holdings-edit-list thead {
+.assets-edit-list thead {
   background: #f8f9fa;
 }
 
-.holdings-edit-list th,
-.holdings-edit-list td {
+.assets-edit-list th,
+.assets-edit-list td {
   padding: 0.75rem;
   text-align: left;
   border-bottom: 1px solid #eee;
 }
 
-.holdings-edit-list th {
+.assets-edit-list th {
   font-weight: 600;
   color: #2c3e50;
 }
 
-.holdings-edit-list tr.removed {
+.assets-edit-list tr.removed {
   opacity: 0.5;
   text-decoration: line-through;
 }

--- a/src/app/portfolios/[id]/page.tsx
+++ b/src/app/portfolios/[id]/page.tsx
@@ -192,7 +192,7 @@ export default function PortfolioDetailPage({ params }: PageProps) {
                 </span>
               </div>
               <div className="stat">
-                <span className="stat-label">Holdings</span>
+                <span className="stat-label">Assets</span>
                 <span className="stat-value stat-value-large">
                   {portfolio.holdings.length}
                 </span>
@@ -206,11 +206,11 @@ export default function PortfolioDetailPage({ params }: PageProps) {
           </div>
 
           <div className="card">
-            <h2>Holdings</h2>
+            <h2>Assets</h2>
             {portfolio.holdings.length === 0 ? (
-              <p className="text-muted">No holdings in this portfolio</p>
+              <p className="text-muted">No assets in this portfolio</p>
             ) : (
-              <div className="holdings-table">
+              <div className="assets-table">
                 <table>
                   <thead>
                     <tr>

--- a/src/components/EditPortfolioForm.tsx
+++ b/src/components/EditPortfolioForm.tsx
@@ -210,13 +210,13 @@ export default function EditPortfolioForm({ portfolio, onSubmit, onCancel }: Edi
 
         <div className="assets-section">
           <div className="section-header">
-            <h3>Holdings ({holdings.filter(h => h.quantity > 0).length})</h3>
+            <h3>Assets ({holdings.filter(h => h.quantity > 0).length})</h3>
             <button
               type="button"
               className="btn btn-secondary btn-small"
               onClick={() => setShowAssetForm(!showAssetForm)}
             >
-              {showAssetForm ? 'Cancel' : 'Add Holding'}
+              {showAssetForm ? 'Cancel' : 'Add Asset'}
             </button>
           </div>
 
@@ -275,13 +275,13 @@ export default function EditPortfolioForm({ portfolio, onSubmit, onCancel }: Edi
                 onClick={handleAddAsset}
                 disabled={isLoadingAsset}
               >
-                {isLoadingAsset ? 'Fetching details...' : 'Add Holding'}
+                {isLoadingAsset ? 'Fetching details...' : 'Add Asset'}
               </button>
             </div>
           )}
 
           {holdings.length > 0 && (
-            <div className="holdings-edit-list">
+            <div className="assets-edit-list">
               <table>
                 <thead>
                   <tr>
@@ -327,7 +327,7 @@ export default function EditPortfolioForm({ portfolio, onSubmit, onCancel }: Edi
                 </tbody>
               </table>
               <p className="text-muted help-text">
-                Tip: Set quantity to 0 or click Remove to delete a holding when you save.
+                Tip: Set quantity to 0 or click Remove to delete an asset when you save.
               </p>
             </div>
           )}

--- a/src/components/PortfolioCard.tsx
+++ b/src/components/PortfolioCard.tsx
@@ -49,15 +49,15 @@ export default function PortfolioCard({ portfolio, onDelete }: PortfolioCardProp
           </span>
         </div>
         <div className="stat">
-          <span className="stat-label">Holdings</span>
+          <span className="stat-label">Assets</span>
           <span className="stat-value">{portfolio.holdings.length}</span>
         </div>
       </div>
 
       <div className="asset-list">
-        <h3>Holdings</h3>
+        <h3>Assets</h3>
         {portfolio.holdings.length === 0 ? (
-          <p className="text-muted">No holdings in this portfolio</p>
+          <p className="text-muted">No assets in this portfolio</p>
         ) : (
           <ul>
             {portfolio.holdings.map((holding) => (


### PR DESCRIPTION
## Summary

Fixes #19 - Standardizes user-facing terminology across the application to consistently use "assets" instead of "holdings". This resolves confusion in the portfolio creation and editing workflows where terminology was inconsistent between the create and edit flows.

## Changes Made

### UI Components Updated (4 files)

- **EditPortfolioForm.tsx** - Updated section heading, button labels ("Add Holding" → "Add Asset"), and help text to use "assets" terminology
- **PortfolioCard.tsx** - Updated stat labels, section headings, and empty state messages
- **Portfolio Detail Page** - Updated stat labels, section headings, and empty state messages  
- **globals.css** - Renamed CSS classes `.holdings-table` → `.assets-table` and `.holdings-edit-list` → `.assets-edit-list` for consistency

### What Changed
- **Before**: Portfolio creation used "Assets", but edit/view used "Holdings"
- **After**: All user-facing text consistently uses "Assets"

### What Stayed the Same
- Internal domain model unchanged (variables, types, API contracts still use "holding" which correctly represents the portfolio-asset relationship)
- All business logic intact
- Database schema unchanged

## Test Plan

- [x] All 210 automated tests pass
- [x] No compilation errors
- [x] Dev server runs successfully
- [x] Manual UI verification:
  - [x] Portfolio list cards show "Assets" stat and heading
  - [x] Portfolio detail page shows "Assets" stat and heading
  - [x] Edit portfolio form shows "Assets" heading and "Add Asset" button
  - [x] Create portfolio form shows "Assets" (already correct)
  - [x] Empty states show "No assets in this portfolio"
  - [x] CSS styling intact for both table types

## Screenshots

Before/after screenshots recommended for reviewer to verify the UI changes.

## Impact

- **Type**: UI/UX improvement
- **Risk**: Low - cosmetic changes only, all tests pass
- **User Impact**: Improved consistency and reduced confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)