### PR TITLE
Support 8-decimal precision for crypto holdings (#22)

### DIFF
--- a/src/app/api/portfolios/[id]/route.ts
+++ b/src/app/api/portfolios/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { portfolioStore } from '@/lib/data/portfolios-db';
 import { UpdatePortfolioRequest, ApiResponse, PortfolioWithValues } from '@/types/api';
 import { requireAuth, handleAuthError } from '@/lib/middleware/auth';
+import { isValidQuantity } from '@/lib/utils/quantity';
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -86,6 +87,17 @@ export async function PUT(
         { error: 'Portfolio name cannot be empty' },
         { status: 400 }
       );
+    }
+
+    if (body.holdings !== undefined) {
+      for (const holding of body.holdings) {
+        if (!isValidQuantity(holding.quantity)) {
+          return NextResponse.json<ApiResponse<never>>(
+            { error: `Invalid quantity for ${holding.assetSymbol}: must be a positive number` },
+            { status: 400 }
+          );
+        }
+      }
     }
 
     // Update portfolio

--- a/src/app/api/portfolios/route.ts
+++ b/src/app/api/portfolios/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { portfolioStore } from '@/lib/data/portfolios-db';
 import { CreatePortfolioRequest, ApiResponse, PortfolioWithValues } from '@/types/api';
 import { requireAuth, handleAuthError } from '@/lib/middleware/auth';
+import { isValidQuantity } from '@/lib/utils/quantity';
 
 // GET /api/portfolios - List all portfolios for authenticated user
 export async function GET(request: NextRequest) {
@@ -44,11 +45,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const holdings = body.holdings || [];
+    for (const holding of holdings) {
+      if (!isValidQuantity(holding.quantity)) {
+        return NextResponse.json<ApiResponse<never>>(
+          { error: `Invalid quantity for ${holding.assetSymbol}: must be a positive number` },
+          { status: 400 }
+        );
+      }
+    }
+
     // Create portfolio with authenticated user's ID
     const portfolio = await portfolioStore.create({
       name: body.name.trim(),
       description: body.description?.trim(),
-      holdings: body.holdings || [],
+      holdings,
       userId: user.userId,
     });
 

--- a/src/app/portfolios/[id]/page.tsx
+++ b/src/app/portfolios/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { PortfolioWithValues, ApiResponse, UpdatePortfolioRequest } from '@/types/api';
 import EditPortfolioForm from '@/components/EditPortfolioForm';
+import { formatQuantity } from '@/lib/utils/quantity';
 
 type PageProps = {
   params: Promise<{ id: string }>;
@@ -236,7 +237,7 @@ export default function PortfolioDetailPage({ params }: PageProps) {
                         <td className="text-right">
                           {formatCurrency(holding.asset.currentPrice)}
                         </td>
-                        <td className="text-right">{holding.quantity}</td>
+                        <td className="text-right">{formatQuantity(holding.quantity, holding.asset.type)}</td>
                         <td className="text-right">
                           <strong>{formatCurrency(holding.totalValue)}</strong>
                         </td>

--- a/src/components/CreatePortfolioForm.tsx
+++ b/src/components/CreatePortfolioForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { CreatePortfolioRequest, AssetType, Holding, CreateAssetRequest, ApiResponse, Asset } from '@/types/api';
+import { quantityStep, formatQuantity } from '@/lib/utils/quantity';
 
 interface CreatePortfolioFormProps {
   onSubmit: (request: CreatePortfolioRequest) => void;
@@ -188,7 +189,7 @@ export default function CreatePortfolioForm({ onSubmit, onCancel }: CreatePortfo
                     value={assetQuantity}
                     onChange={(e) => setAssetQuantity(e.target.value)}
                     placeholder="10"
-                    step="0.0001"
+                    step={quantityStep(assetType)}
                     min="0"
                   />
                 </div>
@@ -226,7 +227,7 @@ export default function CreatePortfolioForm({ onSubmit, onCancel }: CreatePortfo
                     <span className="asset-badge">{holding.assetType}</span>
                   </div>
                   <div>
-                    Qty: {holding.quantity}
+                    Qty: {formatQuantity(holding.quantity, holding.assetType)}
                     {holding.currentPrice && ` @ $${holding.currentPrice}`}
                     <button
                       type="button"

--- a/src/components/EditPortfolioForm.tsx
+++ b/src/components/EditPortfolioForm.tsx
@@ -9,6 +9,7 @@ import {
   CreateAssetRequest,
   ApiResponse
 } from '@/types/api';
+import { quantityStep } from '@/lib/utils/quantity';
 
 interface EditPortfolioFormProps {
   portfolio: PortfolioWithValues;
@@ -256,7 +257,7 @@ export default function EditPortfolioForm({ portfolio, onSubmit, onCancel }: Edi
                     value={assetQuantity}
                     onChange={(e) => setAssetQuantity(e.target.value)}
                     placeholder="10"
-                    step="0.0001"
+                    step={quantityStep(assetType)}
                     min="0"
                     disabled={isLoadingAsset}
                   />
@@ -308,7 +309,7 @@ export default function EditPortfolioForm({ portfolio, onSubmit, onCancel }: Edi
                           type="number"
                           value={holding.quantity}
                           onChange={(e) => handleUpdateQuantity(holding.assetSymbol, e.target.value)}
-                          step="0.0001"
+                          step={quantityStep(holding.assetType)}
                           min="0"
                           className="quantity-input"
                         />

--- a/src/components/PortfolioCard.tsx
+++ b/src/components/PortfolioCard.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { PortfolioWithValues } from '@/types/api';
+import { formatQuantity } from '@/lib/utils/quantity';
 
 interface PortfolioCardProps {
   portfolio: PortfolioWithValues;
@@ -69,9 +70,9 @@ export default function PortfolioCard({ portfolio, onDelete }: PortfolioCardProp
                   <span className="asset-badge">{holding.asset.type}</span>
                 </div>
                 <div className="asset-details">
-                  <span>Quantity: {holding.quantity}</span>
+                  <span>Quantity: {formatQuantity(holding.quantity, holding.asset.type)}</span>
                   <span>
-                    {formatCurrency(holding.asset.currentPrice)} × {holding.quantity} ={' '}
+                    {formatCurrency(holding.asset.currentPrice)} × {formatQuantity(holding.quantity, holding.asset.type)} ={' '}
                     {formatCurrency(holding.totalValue)}
                   </span>
                 </div>

--- a/src/lib/utils/__tests__/quantity.test.ts
+++ b/src/lib/utils/__tests__/quantity.test.ts
@@ -1,0 +1,91 @@
+import {
+  CRYPTO_DECIMALS,
+  STOCK_DECIMALS,
+  decimalsForType,
+  quantityStep,
+  formatQuantity,
+  isValidQuantity,
+} from '../quantity';
+
+describe('decimalsForType', () => {
+  it('returns 8 for crypto', () => {
+    expect(decimalsForType('crypto')).toBe(CRYPTO_DECIMALS);
+    expect(CRYPTO_DECIMALS).toBe(8);
+  });
+
+  it('returns 4 for stock', () => {
+    expect(decimalsForType('stock')).toBe(STOCK_DECIMALS);
+    expect(STOCK_DECIMALS).toBe(4);
+  });
+});
+
+describe('quantityStep', () => {
+  it('returns 0.00000001 for crypto', () => {
+    expect(quantityStep('crypto')).toBe('0.00000001');
+  });
+
+  it('returns 0.0001 for stock', () => {
+    expect(quantityStep('stock')).toBe('0.0001');
+  });
+});
+
+describe('formatQuantity', () => {
+  it('renders crypto values with up to 8 decimals', () => {
+    expect(formatQuantity(1.23456789, 'crypto')).toBe('1.23456789');
+  });
+
+  it('rounds crypto values past the 8th decimal', () => {
+    expect(formatQuantity(1.234567894, 'crypto')).toBe('1.23456789');
+  });
+
+  it('renders the smallest crypto unit without scientific notation', () => {
+    expect(formatQuantity(0.00000001, 'crypto')).toBe('0.00000001');
+  });
+
+  it('trims trailing zeros for crypto', () => {
+    expect(formatQuantity(10, 'crypto')).toBe('10');
+    expect(formatQuantity(1.5, 'crypto')).toBe('1.5');
+  });
+
+  it('caps stock values at 4 decimals', () => {
+    expect(formatQuantity(1.23456, 'stock')).toBe('1.2346');
+  });
+
+  it('trims trailing zeros for stock', () => {
+    expect(formatQuantity(1.5, 'stock')).toBe('1.5');
+    expect(formatQuantity(100, 'stock')).toBe('100');
+  });
+
+  it('does not insert thousands separators', () => {
+    expect(formatQuantity(1234567, 'crypto')).toBe('1234567');
+  });
+});
+
+describe('isValidQuantity', () => {
+  it('accepts the smallest crypto unit', () => {
+    expect(isValidQuantity(0.00000001)).toBe(true);
+  });
+
+  it('accepts typical positive values', () => {
+    expect(isValidQuantity(1)).toBe(true);
+    expect(isValidQuantity(1e10)).toBe(true);
+  });
+
+  it('rejects zero, negative, and non-finite numbers', () => {
+    expect(isValidQuantity(0)).toBe(false);
+    expect(isValidQuantity(-1)).toBe(false);
+    expect(isValidQuantity(Number.NaN)).toBe(false);
+    expect(isValidQuantity(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it('rejects non-number types', () => {
+    expect(isValidQuantity('5')).toBe(false);
+    expect(isValidQuantity(null)).toBe(false);
+    expect(isValidQuantity(undefined)).toBe(false);
+    expect(isValidQuantity({})).toBe(false);
+  });
+
+  it('rejects values that exceed the DECIMAL(20, 8) integer range', () => {
+    expect(isValidQuantity(1e13)).toBe(false);
+  });
+});

--- a/src/lib/utils/quantity.ts
+++ b/src/lib/utils/quantity.ts
@@ -1,0 +1,32 @@
+import { AssetType } from '@/types/api';
+
+export const CRYPTO_DECIMALS = 8;
+export const STOCK_DECIMALS = 4;
+
+const MAX_QUANTITY = 1e12;
+
+export function decimalsForType(type: AssetType): number {
+  return type === 'crypto' ? CRYPTO_DECIMALS : STOCK_DECIMALS;
+}
+
+export function quantityStep(type: AssetType): string {
+  return type === 'crypto' ? '0.00000001' : '0.0001';
+}
+
+export function formatQuantity(value: number, type: AssetType): string {
+  const decimals = decimalsForType(type);
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: decimals,
+    minimumFractionDigits: 0,
+    useGrouping: false,
+  }).format(value);
+}
+
+export function isValidQuantity(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value > 0 &&
+    value <= MAX_QUANTITY
+  );
+}


### PR DESCRIPTION
Closes #22.

## Summary

- Crypto holdings now accept and display up to 8 decimal places (BTC's satoshi precision); stocks keep their 4-decimal behavior.
- Centralized precision rules in a new `src/lib/utils/quantity.ts` module exposing `quantityStep`, `formatQuantity`, and `isValidQuantity`.
- Hardened `POST /api/portfolios` and `PUT /api/portfolios/[id]` with a quantity guard so invalid values now return `400` instead of surfacing the DB `CHECK` constraint as a `500`.

## Why this works without a migration

`holdings.quantity` is already `DECIMAL(20, 8)` in `migrations/001_initial_schema.sql`. The bug was purely client-side: `<input type="number" step="0.0001">` blocked 5–8 decimal entry in the browser. The fix sets `step` per asset type and adds display formatting via `Intl.NumberFormat` so small crypto values don't fall back to scientific notation.

## Files changed

- `src/lib/utils/quantity.ts` (new) — precision constants + helpers.
- `src/lib/utils/__tests__/quantity.test.ts` (new) — 16 unit tests.
- `src/components/CreatePortfolioForm.tsx`, `src/components/EditPortfolioForm.tsx` — dynamic `step`.
- `src/components/PortfolioCard.tsx`, `src/app/portfolios/[id]/page.tsx` — formatted display.
- `src/app/api/portfolios/route.ts`, `src/app/api/portfolios/[id]/route.ts` — `isValidQuantity` guard.

## Test plan

### Automated (already green locally)
- [x] `npm run type-check` — clean
- [x] `npm test` — 226/226 passing (16 new in `quantity.test.ts`)
- [x] `npm run lint` — clean

### QA — happy path
- [ ] Create portfolio → Add Asset → select **Crypto** → enter symbol `BTC`, quantity `0.12345678` → save. Reopen the portfolio detail page; quantity reads `0.12345678` (not rounded, not scientific notation).
- [ ] Create portfolio → Add Asset → select **Stock** → confirm the quantity input still increments by `0.0001` (browser DevTools: `step="0.0001"`).
- [ ] Edit an existing crypto holding → change to `0.00000001` → save → reload → value persists exactly.
- [ ] Edit an existing stock holding → confirm `step="0.0001"` on the per-row input.

### QA — display
- [ ] On the portfolio list (`/portfolios`), a crypto holding of `1` displays as `1` (no trailing zeros), and `0.5` as `0.5`.
- [ ] On the portfolio detail page, the assets table renders crypto quantities with up to 8 decimals and stock quantities with up to 4.
- [ ] Tiny crypto values (`0.00000001`) render literally — no `1e-8` scientific notation.

### QA — API guard
- [ ] `curl` POST `/api/portfolios` with a holding `quantity: -1` (authenticated) → expect `400` and the message `Invalid quantity for <SYMBOL>: must be a positive number`.
- [ ] Same for `quantity: 0`, `quantity: "5"` (string), `quantity: null`.
- [ ] PUT `/api/portfolios/[id]` with the same invalid bodies → same 400 response.

### Regression
- [ ] Existing stock-only portfolios still load, edit, and save without behavior changes.
- [ ] Total-value calculations on `PortfolioCard` and the detail page remain unchanged for existing data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)