### PR TITLE
Upgrade RDS PostgreSQL engine version from 17.2 to 17.9

### DIFF
--- a/infra/main.yaml
+++ b/infra/main.yaml
@@ -42,7 +42,7 @@ Parameters:
 
   DBEngineVersion:
     Type: String
-    Default: '17.2'
+    Default: '17.9'
     Description: PostgreSQL engine version
 
   # HTTPS Configuration Parameters

--- a/infra/parameters.json
+++ b/infra/parameters.json
@@ -21,6 +21,6 @@
   },
   {
     "ParameterKey": "DBEngineVersion",
-    "ParameterValue": "17.2"
+    "ParameterValue": "17.9"
   }
 ]


### PR DESCRIPTION
## Summary
- AWS deprecated PostgreSQL 17.2; pin both the CloudFormation default in `infra/main.yaml` and the `DBEngineVersion` value in `infra/parameters.json` to `17.9`.
- The live `portyfoul-infra` stack in `us-east-2` has already been updated out-of-band to `17.9` via a CloudFormation change set; this PR brings the repo into sync so future stack updates and the GitHub Actions deploy workflow stay on a supported minor.

## Test plan
- [x] Live stack updated and `aws rds describe-db-instances --db-instance-identifier portyfoul-dev-postgres` reports `EngineVersion=17.9`, `Status=available`.
- [x] CFN parameter `DBEngineVersion` recorded as `17.9` on stack `portyfoul-infra`.
- [x] ECS web (2/2) and worker (1/1) services healthy after the rolling redeploy.
- [x] App smoke test: `curl -I https://porty.halfzed.com/` returns `HTTP 200`.
- [x] Pre-upgrade snapshot `portyfoul-dev-pre-17-9-upgrade` retained as recovery point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)